### PR TITLE
Implemented curriculum dropdown

### DIFF
--- a/src/Components/YamlContent.js
+++ b/src/Components/YamlContent.js
@@ -15,6 +15,10 @@ module.exports = fs.readFileSync(require.resolve('../data/training-modules.yaml'
 //using js-yaml for converting yaml into json format for parsing
 const module_data = YAML.load(raw);
 
+const raw_curricula = preval`const fs = require('fs');
+module.exports = fs.readFileSync(require.resolve('../data/curriculum.yaml'), 'utf8');`;
+
+const curricula_data = YAML.load(raw_curricula);
 
 const Status = (props) => {
   const onSelectValueChanged = (event) =>{
@@ -33,6 +37,19 @@ const Status = (props) => {
   )
 }
 
+const Curriculum = (props) => {
+  const onCurriculaValueChanged = (event) =>{
+    props.curriculaValueSelected(event.target.value);
+  }
+  return(
+    <div className={styles.curriculum}>
+      <h4>Curriculum: </h4>
+      <select className={filterstyle.dropdown} id="dropdown" onChange={onCurriculaValueChanged} defaultValue="none">
+        {props.curriculum.map( obj => <option value={obj.curricula} >{obj.curricula}</option> )};
+      </select>
+    </div>
+  )
+}
 
 const Video = (props) => {
   const onCheckValueChanged = () =>{
@@ -62,10 +79,26 @@ const YamlContent = () => {
   
   let [selectTextValue, updateSelectText] = useState('none');
   let [checkValue, updateCheckValue] = useState(false);
-
-  //filtering the module_data list based on the status attribute and output - selectFilteredList
+  let [curriculaValue, updateCurriculaValue] = useState('All');
   
-  let selectFilteredList = module_data.filter((obj) => {
+  //Categorising the modules based on their curricula and output - selectedCurriculaList
+
+  let selectedCurriculaList = [];
+  if (curriculaValue ==='All' ){
+    selectedCurriculaList = module_data;
+  }
+  else{
+    let curricula_list = curricula_data.filter((obj)=> obj.curricula === curriculaValue);
+    let test = curricula_list[0].name_list;
+    for(let i = 0 ; i < test.length ; i++)
+      selectedCurriculaList.push(...module_data.filter((obj)=> obj.name === test[i]))
+    }
+  
+  
+  
+  //filtering the selectedCurriculaList list based on the status attribute and output - selectFilteredList
+  
+  let selectFilteredList = selectedCurriculaList.filter((obj) => {
     if(selectTextValue === "none"){
       return obj;
     }
@@ -92,13 +125,19 @@ const YamlContent = () => {
   const onSelectValueSelected = (filterValue) => {
     updateSelectText(filterValue);
   }
+  const onCurriculaValueSelected = (curriculaValue) =>{
+    updateCurriculaValue(curriculaValue);
+  }
+
   
   return(
     <>
       <div className={styles.container}>
 
+      <Curriculum curriculum = {curricula_data} curriculaValueSelected={onCurriculaValueSelected} />
+
         {/* Filter options for training module */}
-        <Filters filterValueSelected = {onSelectValueSelected} checkValueSelected = {onCheckValueSelected}/>
+        <Filters filterValueSelected = {onSelectValueSelected} checkValueSelected = {onCheckValueSelected} />
 
         <div className={styles.flex_row}>
 

--- a/src/data/curriculum.yaml
+++ b/src/data/curriculum.yaml
@@ -1,0 +1,16 @@
+- name_list: []
+  curricula: 'All'
+- name_list: ['The UNIX Shell','Version controlling with git','Programming with python','SSH','Machine learning','Matplotlib for HEP','<code>ROOT</code>']
+  curricula: 'Basics'
+- name_list: ['Version controlling with git','Advanced git','CI/CD (gitlab)','CI/CD (github)','Docker','Singularity','Unit testing','Level up your python']
+  curricula: 'Software Development and Deployment'
+- name_list: ['HEP C++ Course','Build systems:  <code>cmake</code>']
+  curricula: 'C++ corner'
+- name_list: ['Machine learning','Machine learning on GPU']
+  curricula: 'Machine learning and other analysis tools'
+- name_list: ['Scikit-HEP','<code>ROOT</code>','<code>UnROOT</code>']
+  curricula: 'HEP specific tools'
+- name_list : ['A simple analysis']
+  curricula: 'Miscellaneous'
+- name_list: ['<code>UnROOT</code>','Distributed file systems and grid computing','Parallel programming','alpaka','Workflows &amp; reproducibility','Documentation','Event generation and MC']
+  curricula: 'Planned, in early development, or archived'

--- a/src/styles/grid.module.css
+++ b/src/styles/grid.module.css
@@ -54,6 +54,15 @@
 .img {
   padding: 10px;
 }
+.curriculum{
+  display: flex;
+  justify-content: center;
+  padding: 20px;
+}
+.curriculum h4{
+  font-size: 20px;
+  margin-right: 10px;
+}
 @media (max-width: 1024px) {
   .flex_col {
     min-width: 70%;


### PR DESCRIPTION
In this PR, the curriculum dropdown has been implemented.

- I have created a `Curriculum.yaml` which contains the curricula name and the list of modules which comes under that particular curricula 
- for ex; 
`- name_list: ['The UNIX Shell','Version controlling with git','Programming with python','SSH','Machine learning','Matplotlib for HEP','<code>ROOT</code>']`
  `  curricula: 'Basics'` 
![image](https://user-images.githubusercontent.com/18377109/223364593-e2941836-1232-4bbf-85db-5470e2cadb61.png)

